### PR TITLE
Add env var for port. Removed port from host.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.6
 
-ENV PGHOST='localhost:5432'
+ENV PGHOST='localhost'
+ENV PGPORT='5432'
 ENV PGDATABASE='postgres'
 ENV PGUSER='postgres@postgres'
 ENV PGPASSWORD='password'


### PR DESCRIPTION
Removed port from `PG_HOST`, leaving only the host. Changed port to PG_PORT. 
This fixes issue #1 where having `host:port` on `PG_HOST` creates the following error: `could not translate host name "localhost:5432" to address`.